### PR TITLE
Add hashbang to build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 docker-compose up --build --force-recreate


### PR DESCRIPTION
I couldn't run `docker-compose` in the build script without this.

Everything else looks good though. If this works for you, go ahead and merge in your PR to the main Guidelines branch.